### PR TITLE
point to github for the mag tutorial

### DIFF
--- a/content/magnetics/magnetics_interpretation.rst
+++ b/content/magnetics/magnetics_interpretation.rst
@@ -388,7 +388,7 @@ We note the following features:
 
 .. _Simpeg: http://simpeg.xyz
 
-.. _tutorial: http://computation.geosci.xyz/case-studies/PF/TKC_PF.html
+.. _tutorial: https://github.com/geoscixyz/computation/blob/main/docs/case-studies/PF/TKC_PF.ipynb
 
 Validation
 ^^^^^^^^^^


### PR DESCRIPTION
remove the link to computation.geosci.xyz and replace it with the github URL (should hopefully fix the failing test in #224)  